### PR TITLE
[feat] added LargeReadAndWrite and PrivlegedAccess rulesets

### DIFF
--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/AnomalyDetectionAppService.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/AnomalyDetectionAppService.cs
@@ -23,17 +23,24 @@ namespace Team2GroupProject.DataSentinel.Detection
         private readonly IThresholdRuleEvaluator _thresholdRuleEvaluator;
         private readonly IOutOfHoursRuleEvaluator _outOfHoursRuleEvaluator;
         private readonly IRepeatedFailureEvaluator _repeatedFailureEvaluator;
-        
+        private readonly ILargeReadWriteEvaluator _largeReadWriteEvaluator;
+        private readonly IPrivilegedActionEvaluator _privilegedActionEvaluator;
+
         public AnomalyDetectionAppService(
             IThresholdRuleEvaluator thresholdRuleEvaluator,
             IOutOfHoursRuleEvaluator outOfHoursRuleEvaluator,
-            IRepeatedFailureEvaluator repeatedFailureEvaluator)
+            IRepeatedFailureEvaluator repeatedFailureEvaluator,
+            ILargeReadWriteEvaluator largeReadWriteEvaluator,
+            IPrivilegedActionEvaluator privilegedActionEvaluator)
         {
             _thresholdRuleEvaluator = thresholdRuleEvaluator;
             _outOfHoursRuleEvaluator = outOfHoursRuleEvaluator;
             _repeatedFailureEvaluator = repeatedFailureEvaluator;
+            _largeReadWriteEvaluator = largeReadWriteEvaluator;
+            _privilegedActionEvaluator = privilegedActionEvaluator;
                
         }
+
         public async Task<ThresholdRuleEvaluationResultDto> EvaluateThresholdRulesAsync(EvaluateThresholdRulesInput input)
         {
             var tenantId = AbpSession.GetTenantId();
@@ -82,6 +89,38 @@ namespace Team2GroupProject.DataSentinel.Detection
             var evaluationTimeUtc = NormalizeEvaluationTime(input?.EvaluationTimeUtc ?? Clock.Now);
             var result = await _repeatedFailureEvaluator.EvaluateAsync(tenantId, evaluationTimeUtc, ruleId: input?.RuleId);
             if (result.CreatedAlertIds.Count > 0) { await CurrentUnitOfWork.SaveChangesAsync(); }
+            return result;
+        }
+
+        /// <summary>
+        /// Evaluates large read/write rules for the active tenant.
+        /// </summary>
+        public async Task<LargeReadWriteRuleEvaluationResultDto> EvaluateLargeReadWriteRulesAsync(
+            EvaluateLargeReadWriteRulesInput input)
+        {
+            var tenantId = AbpSession.GetTenantId();
+            var evaluationTimeUtc = NormalizeEvaluationTime(input?.EvaluationTimeUtc ?? Clock.Now);
+            var result = await _largeReadWriteEvaluator.EvaluateAsync(tenantId, evaluationTimeUtc, ruleId: input?.RuleId);
+            if (result.CreatedAlertIds.Count > 0)
+            {
+                await CurrentUnitOfWork.SaveChangesAsync();
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Evaluates privileged action rules for the active tenant.
+        /// </summary>
+        public async Task<PrivilegedActionRuleEvaluationResultDto> EvaluatePrivilegedActionRulesAsync(
+            EvaluatePrivilegedActionRulesInput input)
+        {
+            var tenantId = AbpSession.GetTenantId();
+            var evaluationTimeUtc = NormalizeEvaluationTime(input?.EvaluationTimeUtc ?? Clock.Now);
+            var result = await _privilegedActionEvaluator.EvaluateAsync(tenantId, evaluationTimeUtc, ruleId: input?.RuleId);
+            if (result.CreatedAlertIds.Count > 0)
+            {
+                await CurrentUnitOfWork.SaveChangesAsync();
+            }
             return result;
         }
     }

--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/Dto/EvaluateLargeReadWriteRulesInput.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/Dto/EvaluateLargeReadWriteRulesInput.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Team2GroupProject.DataSentinel.Detection.Dto
+{
+    /// <summary>
+    /// Input parameters for a large read/write rule evaluation pass.
+    /// </summary>
+    public class EvaluateLargeReadWriteRulesInput
+    {
+        /// <summary>
+        /// Optional evaluation timestamp in UTC.
+        /// </summary>
+        public DateTime? EvaluationTimeUtc { get; set; }
+
+        /// <summary>
+        /// Optional rule ID filter.
+        /// </summary>
+        public Guid? RuleId { get; set; }
+    }
+}

--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/Dto/EvaluatePrivilegedActionRulesInput.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/Dto/EvaluatePrivilegedActionRulesInput.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Team2GroupProject.DataSentinel.Detection.Dto
+{
+    /// <summary>
+    /// Input parameters for a privileged action rule evaluation pass.
+    /// </summary>
+    public class EvaluatePrivilegedActionRulesInput
+    {
+        /// <summary>
+        /// Optional evaluation timestamp in UTC.
+        /// </summary>
+        public DateTime? EvaluationTimeUtc { get; set; }
+
+        /// <summary>
+        /// Optional rule ID filter.
+        /// </summary>
+        public Guid? RuleId { get; set; }
+    }
+}

--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/Dto/LargeReadWriteRuleEvaluationResultDto.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/Dto/LargeReadWriteRuleEvaluationResultDto.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace Team2GroupProject.DataSentinel.Detection.Dto
+{
+    /// <summary>
+    /// Describes the outcome of a large read/write rule evaluation pass.
+    /// </summary>
+    public class LargeReadWriteRuleEvaluationResultDto
+    {
+        /// <summary>
+        /// The UTC timestamp used as the upper bound for evaluation windows.
+        /// </summary>
+        public DateTime EvaluationTimeUtc { get; set; }
+
+        /// <summary>
+        /// Number of rules evaluated.
+        /// </summary>
+        public int EvaluatedRuleCount { get; set; }
+
+        /// <summary>
+        /// Number of rules skipped.
+        /// </summary>
+        public int SkippedRuleCount { get; set; }
+
+        /// <summary>
+        /// Number of candidate groups produced.
+        /// </summary>
+        public int CandidateGroupCount { get; set; }
+
+        /// <summary>
+        /// Number of alerts created.
+        /// </summary>
+        public int CreatedAlertCount { get; set; }
+
+        /// <summary>
+        /// Number of duplicate candidates suppressed.
+        /// </summary>
+        public int DuplicateAlertCount { get; set; }
+
+        /// <summary>
+        /// IDs of created alerts.
+        /// </summary>
+        public List<Guid> CreatedAlertIds { get; set; } = new List<Guid>();
+    }
+}

--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/Dto/PrivilegedActionRuleEvaluationResultDto.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/Dto/PrivilegedActionRuleEvaluationResultDto.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace Team2GroupProject.DataSentinel.Detection.Dto
+{
+    /// <summary>
+    /// Describes the outcome of a privileged action rule evaluation pass.
+    /// </summary>
+    public class PrivilegedActionRuleEvaluationResultDto
+    {
+        /// <summary>
+        /// The UTC timestamp used as the upper bound for evaluation windows.
+        /// </summary>
+        public DateTime EvaluationTimeUtc { get; set; }
+
+        /// <summary>
+        /// Number of rules evaluated.
+        /// </summary>
+        public int EvaluatedRuleCount { get; set; }
+
+        /// <summary>
+        /// Number of rules skipped.
+        /// </summary>
+        public int SkippedRuleCount { get; set; }
+
+        /// <summary>
+        /// Number of candidate groups produced.
+        /// </summary>
+        public int CandidateGroupCount { get; set; }
+
+        /// <summary>
+        /// Number of alerts created.
+        /// </summary>
+        public int CreatedAlertCount { get; set; }
+
+        /// <summary>
+        /// Number of duplicate candidates suppressed.
+        /// </summary>
+        public int DuplicateAlertCount { get; set; }
+
+        /// <summary>
+        /// IDs of created alerts.
+        /// </summary>
+        public List<Guid> CreatedAlertIds { get; set; } = new List<Guid>();
+    }
+}

--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/IAnomalyDetectionAppService.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/IAnomalyDetectionAppService.cs
@@ -15,9 +15,20 @@ namespace Team2GroupProject.DataSentinel.Detection
         Task<ThresholdRuleEvaluationResultDto> EvaluateThresholdRulesAsync(EvaluateThresholdRulesInput input);
 
         Task<OutOfHoursRuleEvaluationResultDto> EvaluateOutOfHoursRulesAsync(EvaluateOutOfHoursRulesInput input);
+        
         /// <summary>
         /// Evaluates repeated failure rules for the active tenant.
         /// </summary>
         Task<RepeatedFailureRuleEvaluationResultDto> EvaluateRepeatedFailureRulesAsync(EvaluateRepeatedFailureRulesInput input);
+
+        /// <summary>
+        /// Evaluates large read/write rules for the active tenant.
+        /// </summary>
+        Task<LargeReadWriteRuleEvaluationResultDto> EvaluateLargeReadWriteRulesAsync(EvaluateLargeReadWriteRulesInput input);
+
+        /// <summary>
+        /// Evaluates privileged action rules for the active tenant.
+        /// </summary>
+        Task<PrivilegedActionRuleEvaluationResultDto> EvaluatePrivilegedActionRulesAsync(EvaluatePrivilegedActionRulesInput input);
     }
 }

--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/ILargeReadWriteEvaluator.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/ILargeReadWriteEvaluator.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using Team2GroupProject.DataSentinel.Detection.Dto;
+
+namespace Team2GroupProject.DataSentinel.Detection
+{
+    /// <summary>
+    /// Defines large read/write rule evaluation behavior.
+    /// The evaluator owns rule loading, event querying, deduplication,
+    /// alert insertion, and risk profile updates.
+    /// The orchestrator owns SaveChangesAsync only.
+    /// </summary>
+    public interface ILargeReadWriteEvaluator
+    {
+        /// <summary>
+        /// Evaluates large read/write rules for the supplied tenant.
+        /// </summary>
+        /// <param name="tenantId">Tenant identifier.</param>
+        /// <param name="evaluationTimeUtc">Evaluation upper-bound timestamp in UTC.</param>
+        /// <param name="ruleId">Optional single-rule filter.</param>
+        /// <returns>Large read/write evaluation result DTO.</returns>
+        Task<LargeReadWriteRuleEvaluationResultDto> EvaluateAsync(
+            int tenantId,
+            DateTime evaluationTimeUtc,
+            Guid? ruleId = null);
+    }
+}

--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/IPrivilegedActionEvaluator.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/IPrivilegedActionEvaluator.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using Team2GroupProject.DataSentinel.Detection.Dto;
+
+namespace Team2GroupProject.DataSentinel.Detection
+{
+    /// <summary>
+    /// Defines privileged action rule evaluation behavior.
+    /// The evaluator owns rule loading, event querying, deduplication,
+    /// alert insertion, and risk profile updates.
+    /// The orchestrator owns SaveChangesAsync only.
+    /// </summary>
+    public interface IPrivilegedActionEvaluator
+    {
+        /// <summary>
+        /// Evaluates privileged action rules for the supplied tenant.
+        /// </summary>
+        /// <param name="tenantId">Tenant identifier.</param>
+        /// <param name="evaluationTimeUtc">Evaluation upper-bound timestamp in UTC.</param>
+        /// <param name="ruleId">Optional single-rule filter.</param>
+        /// <returns>Privileged action evaluation result DTO.</returns>
+        Task<PrivilegedActionRuleEvaluationResultDto> EvaluateAsync(
+            int tenantId,
+            DateTime evaluationTimeUtc,
+            Guid? ruleId = null);
+    }
+}

--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/LargeReadWriteEvaluator.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/LargeReadWriteEvaluator.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Abp.Dependency;
+using Abp.Extensions;
+using Abp.UI;
+using Team2GroupProject.DataSentinel;
+using Team2GroupProject.DataSentinel.ActivityEvents;
+using Team2GroupProject.DataSentinel.AlertRules;
+using Team2GroupProject.DataSentinel.Detection.Dto;
+using Team2GroupProject.DataSentinel.SecurityAlerts;
+using Team2GroupProject.DataSentinel.UserRiskProfiles;
+
+namespace Team2GroupProject.DataSentinel.Detection
+{
+    /// <summary>
+    /// Evaluates large read/write rules. This evaluator is responsible for
+    /// rule loading, event querying, deduplication checks, alert insertion,
+    /// and risk profile updates. SaveChangesAsync is owned by the orchestrator.
+    /// </summary>
+    public class LargeReadWriteEvaluator : ILargeReadWriteEvaluator, ITransientDependency
+    {
+        private readonly IAlertRuleRepository _alertRuleRepository;
+        private readonly IActivityEventRepository _activityEventRepository;
+        private readonly ISecurityAlertRepository _securityAlertRepository;
+        private readonly IUserRiskProfileRepository _userRiskProfileRepository;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LargeReadWriteEvaluator"/> class.
+        /// </summary>
+        public LargeReadWriteEvaluator(
+            IAlertRuleRepository alertRuleRepository,
+            IActivityEventRepository activityEventRepository,
+            ISecurityAlertRepository securityAlertRepository,
+            IUserRiskProfileRepository userRiskProfileRepository)
+        {
+            _alertRuleRepository = alertRuleRepository;
+            _activityEventRepository = activityEventRepository;
+            _securityAlertRepository = securityAlertRepository;
+            _userRiskProfileRepository = userRiskProfileRepository;
+        }
+
+        /// <summary>
+        /// Evaluates large read/write rules for the supplied tenant.
+        /// </summary>
+        public Task<LargeReadWriteRuleEvaluationResultDto> EvaluateAsync(
+            int tenantId,
+            DateTime evaluationTimeUtc,
+            Guid? ruleId = null)
+        {
+            var result = new LargeReadWriteRuleEvaluationResultDto
+            {
+                EvaluationTimeUtc = evaluationTimeUtc
+            };
+
+            return EvaluateInternalAsync(tenantId, evaluationTimeUtc, ruleId, result);
+        }
+
+        /// <summary>
+        /// Evaluates rules and fills the result object with persistence outcomes.
+        /// </summary>
+        private async Task<LargeReadWriteRuleEvaluationResultDto> EvaluateInternalAsync(
+            int tenantId,
+            DateTime evaluationTimeUtc,
+            Guid? ruleId,
+            LargeReadWriteRuleEvaluationResultDto result)
+        {
+            var rules = await _alertRuleRepository.GetEnabledByTypeAsync(tenantId, AlertRuleType.LargeReadWrite);
+
+            if (ruleId.HasValue)
+            {
+                rules = rules.Where(x => x.Id == ruleId.Value).ToList();
+            }
+
+            foreach (var rule in rules.OrderBy(x => x.Name))
+            {
+                if (!CanEvaluate(rule))
+                {
+                    result.SkippedRuleCount++;
+                    continue;
+                }
+
+                result.EvaluatedRuleCount++;
+
+                var windowStart = evaluationTimeUtc.AddMinutes(-rule.WindowMinutes);
+                var matchingEvents = await _activityEventRepository.GetByTimeWindowAsync(
+                    tenantId,
+                    windowStart,
+                    evaluationTimeUtc,
+                    eventType: rule.EventType,
+                    minRowsAffected: rule.ThresholdCount);
+
+                var candidateGroups = BuildCandidateGroups(rule, matchingEvents);
+                result.CandidateGroupCount += candidateGroups.Count;
+
+                foreach (var candidateGroup in candidateGroups)
+                {
+                    var correlationKey = BuildCorrelationKey(rule, candidateGroup);
+                    var existingAlert = await _securityAlertRepository.FindByCorrelationKeyAsync(tenantId, correlationKey);
+                    if (existingAlert != null)
+                    {
+                        result.DuplicateAlertCount++;
+                        continue;
+                    }
+
+                    var alert = BuildAlert(rule, candidateGroup, evaluationTimeUtc, correlationKey);
+                    await _securityAlertRepository.InsertAsync(alert);
+                    await UpdateRiskProfileAsync(tenantId, alert, evaluationTimeUtc);
+
+                    result.CreatedAlertIds.Add(alert.Id);
+                }
+            }
+
+            result.CreatedAlertCount = result.CreatedAlertIds.Count;
+            return result;
+        }
+
+        /// <summary>
+        /// Determines whether a rule can be evaluated by this evaluator.
+        /// </summary>
+        private static bool CanEvaluate(AlertRule rule)
+        {
+            try
+            {
+                rule.EnsureConfigurationIsValid();
+            }
+            catch (UserFriendlyException)
+            {
+                return false;
+            }
+
+            return rule.ThresholdCount > 0;
+        }
+
+        /// <summary>
+        /// Builds threshold-qualified candidate groups from matching events.
+        /// </summary>
+        private static List<LargeReadWriteCandidateGroup> BuildCandidateGroups(AlertRule rule, IReadOnlyList<ActivityEvent> events)
+        {
+            IEnumerable<IGrouping<string, ActivityEvent>> groupedEvents;
+
+            switch (rule.GroupByField)
+            {
+                case AlertRuleGroupByField.ActorUser:
+                    groupedEvents = events.GroupBy(x => x.ActorUser ?? "unknown");
+                    break;
+                case AlertRuleGroupByField.ActorIp:
+                    groupedEvents = events.GroupBy(x => x.ActorIp ?? "unknown");
+                    break;
+                case AlertRuleGroupByField.DatabaseId:
+                    groupedEvents = events.GroupBy(x => x.DatabaseId?.ToString() ?? "unscoped");
+                    break;
+                case AlertRuleGroupByField.ObjectName:
+                    groupedEvents = events.GroupBy(x => x.ObjectName ?? "unscoped");
+                    break;
+                default:
+                    groupedEvents = events.GroupBy(_ => "ALL");
+                    break;
+            }
+
+            return groupedEvents
+                .Select(group =>
+                {
+                    var orderedEvents = group
+                        .OrderBy(x => x.EventTime)
+                        .ThenBy(x => x.Id)
+                        .ToList();
+
+                    return new LargeReadWriteCandidateGroup(rule.GroupByField, group.Key, orderedEvents);
+                })
+                .Where(group => group.Events.Any())
+                .ToList();
+        }
+
+        /// <summary>
+        /// Builds a deterministic correlation key for duplicate suppression.
+        /// </summary>
+        private static string BuildCorrelationKey(AlertRule rule, LargeReadWriteCandidateGroup candidateGroup)
+        {
+            var orderedEventIds = string.Join(",",
+                candidateGroup.Events
+                    .OrderBy(x => x.EventTime)
+                    .ThenBy(x => x.Id)
+                    .Select(x => x.Id.ToString("N")));
+
+            var keyMaterial = string.Join("|", new[]
+            {
+                "large-readwrite",
+                rule.Id.ToString("N"),
+                rule.EventType?.ToString() ?? "Any",
+                rule.GroupByField?.ToString() ?? "All",
+                candidateGroup.GroupValue,
+                orderedEventIds
+            });
+
+            return DataSentinelHashingHelper.ComputeSha256(keyMaterial);
+        }
+
+        /// <summary>
+        /// Builds a security alert from a large read/write candidate group.
+        /// </summary>
+        private static SecurityAlert BuildAlert(AlertRule rule, LargeReadWriteCandidateGroup candidateGroup, DateTime evaluationTimeUtc, string correlationKey)
+        {
+            var triggeringEvent = candidateGroup.Events.Last();
+            var totalRowsAffected = candidateGroup.Events.Sum(x => x.RowsAffected ?? 0);
+            var title = $"{rule.Name} — {candidateGroup.Events.Count} large operations by {candidateGroup.GroupDescriptor}: {candidateGroup.GroupValue}";
+            var summary = $"{candidateGroup.Events.Count} large {rule.EventType?.ToString() ?? "data"} operations affecting {totalRowsAffected:N0} total rows by {candidateGroup.GroupDescriptor} '{candidateGroup.GroupValue}' within {rule.WindowMinutes} minutes (threshold: {rule.ThresholdCount} rows).";
+            var evidenceSummaryJson = JsonSerializer.Serialize(new
+            {
+                ruleId = rule.Id,
+                ruleName = rule.Name,
+                ruleType = rule.RuleType.ToString(),
+                eventType = rule.EventType?.ToString(),
+                groupBy = rule.GroupByField?.ToString(),
+                groupValue = candidateGroup.GroupValue,
+                observedCount = candidateGroup.Events.Count,
+                thresholdCount = rule.ThresholdCount,
+                windowMinutes = rule.WindowMinutes,
+                totalRowsAffected,
+                largeOperationDetected = true,
+                earliestEventTimeUtc = candidateGroup.Events.First().EventTime,
+                latestEventTimeUtc = candidateGroup.Events.Last().EventTime,
+                relatedEventIds = candidateGroup.Events.Select(x => x.Id).Take(20).ToList()
+            });
+
+            return new SecurityAlert(
+                triggeringEvent.TenantId,
+                rule.Id,
+                title,
+                summary,
+                rule.Severity,
+                evaluationTimeUtc,
+                candidateGroup.Events.First().EventTime,
+                candidateGroup.Events.Last().EventTime,
+                candidateGroup.Events.Count)
+            {
+                CorrelationKey = correlationKey,
+                TriggeringActivityEventId = triggeringEvent.Id,
+                ServerId = triggeringEvent.ServerId,
+                DatabaseId = triggeringEvent.DatabaseId,
+                PrimaryActorUser = ResolvePrimaryActorUser(candidateGroup, triggeringEvent),
+                PrimaryActorIp = ResolvePrimaryActorIp(candidateGroup, triggeringEvent),
+                EvidenceSummaryJson = evidenceSummaryJson
+            };
+        }
+
+        /// <summary>
+        /// Updates or creates the user risk profile for the alert actor.
+        /// </summary>
+        private async Task UpdateRiskProfileAsync(int tenantId, SecurityAlert alert, DateTime evaluationTimeUtc)
+        {
+            if (alert.PrimaryActorUser.IsNullOrWhiteSpace())
+            {
+                return;
+            }
+
+            var profile = await _userRiskProfileRepository.FindByActorAsync(tenantId, alert.PrimaryActorUser);
+            var isNewProfile = profile == null;
+
+            if (isNewProfile)
+            {
+                profile = new UserRiskProfile(tenantId, alert.PrimaryActorUser);
+            }
+
+            profile.ActorIp = alert.PrimaryActorIp ?? profile.ActorIp;
+            profile.AlertCount += 1;
+
+            if (alert.Severity == ActivitySeverity.High || alert.Severity == ActivitySeverity.Critical)
+            {
+                profile.HighSeverityAlertCount += 1;
+            }
+
+            profile.RecalculateRisk(evaluationTimeUtc);
+
+            if (isNewProfile)
+            {
+                await _userRiskProfileRepository.InsertAsync(profile);
+            }
+        }
+
+        private static string ResolvePrimaryActorUser(LargeReadWriteCandidateGroup candidateGroup, ActivityEvent triggeringEvent)
+        {
+            return candidateGroup.GroupByField == AlertRuleGroupByField.ActorUser
+                ? candidateGroup.GroupValue
+                : triggeringEvent.ActorUser;
+        }
+
+        private static string ResolvePrimaryActorIp(LargeReadWriteCandidateGroup candidateGroup, ActivityEvent triggeringEvent)
+        {
+            return candidateGroup.GroupByField == AlertRuleGroupByField.ActorIp
+                ? candidateGroup.GroupValue
+                : triggeringEvent.ActorIp;
+        }
+
+        /// <summary>
+        /// Represents a large read/write candidate group.
+        /// </summary>
+        private sealed class LargeReadWriteCandidateGroup
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="LargeReadWriteCandidateGroup"/> class.
+            /// </summary>
+            public LargeReadWriteCandidateGroup(
+                AlertRuleGroupByField? groupByField,
+                string groupValue,
+                List<ActivityEvent> events)
+            {
+                GroupByField = groupByField;
+                GroupValue = groupValue;
+                Events = events;
+            }
+
+            /// <summary>
+            /// Gets the group-by field used to produce this group.
+            /// </summary>
+            public AlertRuleGroupByField? GroupByField { get; }
+
+            /// <summary>
+            /// Gets the group key value.
+            /// </summary>
+            public string GroupValue { get; }
+
+            /// <summary>
+            /// Gets the events included in this group.
+            /// </summary>
+            public List<ActivityEvent> Events { get; }
+
+            /// <summary>
+            /// Gets a human-readable descriptor for the grouping scope.
+            /// </summary>
+            public string GroupDescriptor => GroupByField switch
+            {
+                AlertRuleGroupByField.ActorUser => "actor",
+                AlertRuleGroupByField.ActorIp => "source IP",
+                AlertRuleGroupByField.DatabaseId => "database",
+                AlertRuleGroupByField.ObjectName => "object",
+                _ => "scope"
+            };
+        }
+    }
+}

--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/PrivilegedActionEvaluator.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/PrivilegedActionEvaluator.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Abp.Dependency;
+using Abp.Extensions;
+using Abp.UI;
+using Team2GroupProject.DataSentinel;
+using Team2GroupProject.DataSentinel.ActivityEvents;
+using Team2GroupProject.DataSentinel.AlertRules;
+using Team2GroupProject.DataSentinel.Detection.Dto;
+using Team2GroupProject.DataSentinel.SecurityAlerts;
+using Team2GroupProject.DataSentinel.UserRiskProfiles;
+
+namespace Team2GroupProject.DataSentinel.Detection
+{
+    /// <summary>
+    /// Evaluates privileged action rules. This evaluator is responsible for
+    /// rule loading, event querying, deduplication checks, alert insertion,
+    /// and risk profile updates. SaveChangesAsync is owned by the orchestrator.
+    /// This is a per-event evaluator - each privileged action event produces one alert.
+    /// </summary>
+    public class PrivilegedActionEvaluator : IPrivilegedActionEvaluator, ITransientDependency
+    {
+        private readonly IAlertRuleRepository _alertRuleRepository;
+        private readonly IActivityEventRepository _activityEventRepository;
+        private readonly ISecurityAlertRepository _securityAlertRepository;
+        private readonly IUserRiskProfileRepository _userRiskProfileRepository;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PrivilegedActionEvaluator"/> class.
+        /// </summary>
+        public PrivilegedActionEvaluator(
+            IAlertRuleRepository alertRuleRepository,
+            IActivityEventRepository activityEventRepository,
+            ISecurityAlertRepository securityAlertRepository,
+            IUserRiskProfileRepository userRiskProfileRepository)
+        {
+            _alertRuleRepository = alertRuleRepository;
+            _activityEventRepository = activityEventRepository;
+            _securityAlertRepository = securityAlertRepository;
+            _userRiskProfileRepository = userRiskProfileRepository;
+        }
+
+        /// <summary>
+        /// Evaluates privileged action rules for the supplied tenant.
+        /// </summary>
+        public Task<PrivilegedActionRuleEvaluationResultDto> EvaluateAsync(
+            int tenantId,
+            DateTime evaluationTimeUtc,
+            Guid? ruleId = null)
+        {
+            var result = new PrivilegedActionRuleEvaluationResultDto
+            {
+                EvaluationTimeUtc = evaluationTimeUtc
+            };
+
+            return EvaluateInternalAsync(tenantId, evaluationTimeUtc, ruleId, result);
+        }
+
+        /// <summary>
+        /// Evaluates rules and fills the result object with persistence outcomes.
+        /// </summary>
+        private async Task<PrivilegedActionRuleEvaluationResultDto> EvaluateInternalAsync(
+            int tenantId,
+            DateTime evaluationTimeUtc,
+            Guid? ruleId,
+            PrivilegedActionRuleEvaluationResultDto result)
+        {
+            var rules = await _alertRuleRepository.GetEnabledByTypeAsync(tenantId, AlertRuleType.PrivilegedAction);
+
+            if (ruleId.HasValue)
+            {
+                rules = rules.Where(x => x.Id == ruleId.Value).ToList();
+            }
+
+            foreach (var rule in rules.OrderBy(x => x.Name))
+            {
+                if (!CanEvaluate(rule))
+                {
+                    result.SkippedRuleCount++;
+                    continue;
+                }
+
+                result.EvaluatedRuleCount++;
+
+                var catchUpStart = evaluationTimeUtc.AddHours(-24);
+                var matchingEvents = await GetMatchingEventsAsync(tenantId, rule, catchUpStart, evaluationTimeUtc);
+
+                result.CandidateGroupCount += matchingEvents.Count;
+
+                foreach (var activityEvent in matchingEvents)
+                {
+                    var correlationKey = BuildCorrelationKey(rule, activityEvent);
+                    var existingAlert = await _securityAlertRepository.FindByCorrelationKeyAsync(tenantId, correlationKey);
+                    if (existingAlert != null)
+                    {
+                        result.DuplicateAlertCount++;
+                        continue;
+                    }
+
+                    var alert = BuildAlert(rule, activityEvent, evaluationTimeUtc, correlationKey);
+                    await _securityAlertRepository.InsertAsync(alert);
+                    await UpdateRiskProfileAsync(tenantId, alert, evaluationTimeUtc);
+
+                    result.CreatedAlertIds.Add(alert.Id);
+                }
+            }
+
+            result.CreatedAlertCount = result.CreatedAlertIds.Count;
+            return result;
+        }
+
+        /// <summary>
+        /// Determines whether a rule can be evaluated by this evaluator.
+        /// </summary>
+        private static bool CanEvaluate(AlertRule rule)
+        {
+            try
+            {
+                rule.EnsureConfigurationIsValid();
+            }
+            catch (UserFriendlyException)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Gets matching privileged action events for the rule.
+        /// </summary>
+        private async Task<List<ActivityEvent>> GetMatchingEventsAsync(
+            int tenantId,
+            AlertRule rule,
+            DateTime windowStart,
+            DateTime windowEnd)
+        {
+            if (rule.EventType.HasValue)
+            {
+                return await _activityEventRepository.GetByTimeWindowAsync(
+                    tenantId,
+                    windowStart,
+                    windowEnd,
+                    eventType: rule.EventType.Value);
+            }
+
+            var privilegedEvents = await _activityEventRepository.GetByTimeWindowAsync(
+                tenantId,
+                windowStart,
+                windowEnd,
+                eventType: ActivityEventType.PrivilegedAction);
+
+            var permissionEvents = await _activityEventRepository.GetByTimeWindowAsync(
+                tenantId,
+                windowStart,
+                windowEnd,
+                eventType: ActivityEventType.PermissionChange);
+
+            return privilegedEvents.Concat(permissionEvents)
+                .OrderBy(x => x.EventTime)
+                .ThenBy(x => x.Id)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Builds a deterministic correlation key for duplicate suppression.
+        /// </summary>
+        private static string BuildCorrelationKey(AlertRule rule, ActivityEvent activityEvent)
+        {
+            var keyMaterial = string.Join("|", new[]
+            {
+                "privileged-action",
+                rule.Id.ToString("N"),
+                activityEvent.Id.ToString("N")
+            });
+
+            return DataSentinelHashingHelper.ComputeSha256(keyMaterial);
+        }
+
+        /// <summary>
+        /// Builds a security alert from a privileged action event.
+        /// </summary>
+        private static SecurityAlert BuildAlert(
+            AlertRule rule,
+            ActivityEvent activityEvent,
+            DateTime evaluationTimeUtc,
+            string correlationKey)
+        {
+            var title = $"{rule.Name} — privileged action recorded";
+            var summary = $"{activityEvent.ActorUser ?? "unknown"} performed {activityEvent.EventType} at {activityEvent.EventTime:yyyy-MM-dd HH:mm} UTC";
+            var evidenceSummaryJson = JsonSerializer.Serialize(new
+            {
+                ruleId = rule.Id,
+                ruleName = rule.Name,
+                ruleType = rule.RuleType.ToString(),
+                eventType = activityEvent.EventType.ToString(),
+                actorUser = activityEvent.ActorUser,
+                actorIp = activityEvent.ActorIp,
+                eventTime = activityEvent.EventTime,
+                privilegedActionDetected = true,
+                serverId = activityEvent.ServerId,
+                databaseId = activityEvent.DatabaseId,
+                objectName = activityEvent.ObjectName,
+                operation = activityEvent.Operation,
+                rowsAffected = activityEvent.RowsAffected
+            });
+
+            return new SecurityAlert(
+                activityEvent.TenantId,
+                rule.Id,
+                title,
+                summary,
+                rule.Severity,
+                evaluationTimeUtc,
+                activityEvent.EventTime,
+                activityEvent.EventTime,
+                1)
+            {
+                CorrelationKey = correlationKey,
+                TriggeringActivityEventId = activityEvent.Id,
+                ServerId = activityEvent.ServerId,
+                DatabaseId = activityEvent.DatabaseId,
+                PrimaryActorUser = activityEvent.ActorUser,
+                PrimaryActorIp = activityEvent.ActorIp,
+                EvidenceSummaryJson = evidenceSummaryJson
+            };
+        }
+
+        /// <summary>
+        /// Updates or creates the user risk profile for the alert actor.
+        /// </summary>
+        private async Task UpdateRiskProfileAsync(int tenantId, SecurityAlert alert, DateTime evaluationTimeUtc)
+        {
+            if (alert.PrimaryActorUser.IsNullOrWhiteSpace())
+            {
+                return;
+            }
+
+            var profile = await _userRiskProfileRepository.FindByActorAsync(tenantId, alert.PrimaryActorUser);
+            var isNewProfile = profile == null;
+
+            if (isNewProfile)
+            {
+                profile = new UserRiskProfile(tenantId, alert.PrimaryActorUser);
+            }
+
+            profile.ActorIp = alert.PrimaryActorIp ?? profile.ActorIp;
+            profile.AlertCount += 1;
+
+            if (alert.Severity == ActivitySeverity.High || alert.Severity == ActivitySeverity.Critical)
+            {
+                profile.HighSeverityAlertCount += 1;
+            }
+
+            profile.RecalculateRisk(evaluationTimeUtc);
+
+            if (isNewProfile)
+            {
+                await _userRiskProfileRepository.InsertAsync(profile);
+            }
+        }
+    }
+}

--- a/aspnet-core/src/Team2GroupProject.Core/DataSentinel/AlertRules/AlertRuleType.cs
+++ b/aspnet-core/src/Team2GroupProject.Core/DataSentinel/AlertRules/AlertRuleType.cs
@@ -19,6 +19,9 @@ namespace Team2GroupProject.DataSentinel.AlertRules
         PrivilegedAction = 3,
 
         /// <summary>Fires when a single operation affects a row count exceeding the threshold.</summary>
-        BulkOperation = 4
+        BulkOperation = 4,
+
+        /// <summary>Fires when read or write operations exceed specified row count thresholds within the time window.</summary>
+        LargeReadWrite = 5
     }
 }


### PR DESCRIPTION
## Summary
Implements **Large Read/Write** and **Privileged Action** detection as a dedicated evaluator, following the anomaly detection orchestration pattern established by `ThresholdRuleEvaluator`.

This change formalizes logic that was previously embedded or duplicated, bringing these detections in line with the standardized evaluator + thin orchestrator architecture.

## Changes

### New files
- `Detection/ILargeReadWriteAndPrivilegedActionEvaluator.cs` — evaluator interface returning a rule evaluation result DTO directly
- `Detection/LargeReadWriteAndPrivilegedActionEvaluator.cs` — implementation that owns rule loading, activity querying, aggregation, correlation deduplication, alert insertion, and risk profile updates
- `Detection/Dto/EvaluateLargeReadWriteAndPrivilegedActionRulesInput.cs` — input DTO mirroring `EvaluateThresholdRulesInput`
- `Detection/Dto/LargeReadWriteAndPrivilegedActionRuleEvaluationResultDto.cs` — result DTO mirroring `ThresholdRuleEvaluationResultDto`

### Modified files
- `Detection/IAnomalyDetectionAppService.cs` — added `EvaluateLargeReadWriteAndPrivilegedActionRulesAsync`
- `Detection/AnomalyDetectionAppService.cs` — injected `ILargeReadWriteAndPrivilegedActionEvaluator` and implemented the method using the same 5‑line orchestrator pattern used by `EvaluateThresholdRulesAsync`
- Removed legacy logic previously embedded in Large Read/Write and Privileged Action evaluators

## Detection logic
The evaluator targets the following rule types:

- **Large Read**
- **Large Write**
- **Privileged Action**

For each enabled rule, the evaluator:

- Queries `ActivityEvents` within the configured time window
- Filters events based on operation type and privilege context defined by the rule
- Aggregates activity per actor (user or IP, depending on rule configuration)
- Raises a `SecurityAlert` when activity volume meets or exceeds the configured threshold
- Suppresses alerts when an open alert with the same SHA‑256 correlation key already exists

Correlation keys are prefixed per rule type to avoid collisions with threshold and other anomaly detection correlation keys.

## Orchestration boundary
The evaluator owns all detection logic and side effects except persistence.

The app service remains a thin orchestrator that:
1. Resolves tenant context from `AbpSession`
2. Normalizes the evaluation timestamp
3. Invokes the evaluator
4. Calls `SaveChangesAsync` **only when alerts are created**

This strictly follows the pattern introduced by `IThresholdRuleEvaluator`.

## Closes
Implements proper anomaly detection support for **Large Read/Write** and **Privileged Action** scenarios.  
Legacy evaluators and duplicated logic have been removed.