### PR TITLE
[debug] fixed LargeReadWrite to use BulkOperation instead of LargeRea…

### DIFF
--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/LargeReadWriteEvaluator.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Detection/LargeReadWriteEvaluator.cs
@@ -16,7 +16,7 @@ using Team2GroupProject.DataSentinel.UserRiskProfiles;
 namespace Team2GroupProject.DataSentinel.Detection
 {
     /// <summary>
-    /// Evaluates large read/write rules. This evaluator is responsible for
+    /// Evaluates bulk operation rules. This evaluator is responsible for
     /// rule loading, event querying, deduplication checks, alert insertion,
     /// and risk profile updates. SaveChangesAsync is owned by the orchestrator.
     /// </summary>
@@ -43,7 +43,7 @@ namespace Team2GroupProject.DataSentinel.Detection
         }
 
         /// <summary>
-        /// Evaluates large read/write rules for the supplied tenant.
+        /// Evaluates bulk operation rules for the supplied tenant.
         /// </summary>
         public Task<LargeReadWriteRuleEvaluationResultDto> EvaluateAsync(
             int tenantId,
@@ -67,7 +67,9 @@ namespace Team2GroupProject.DataSentinel.Detection
             Guid? ruleId,
             LargeReadWriteRuleEvaluationResultDto result)
         {
-            var rules = await _alertRuleRepository.GetEnabledByTypeAsync(tenantId, AlertRuleType.LargeReadWrite);
+            // LargeReadWrite was consolidated into BulkOperation; EnsureConfigurationIsValid
+            // validates WindowMinutes and ThresholdCount for BulkOperation rules (issue #37 fix).
+            var rules = await _alertRuleRepository.GetEnabledByTypeAsync(tenantId, AlertRuleType.BulkOperation);
 
             if (ruleId.HasValue)
             {
@@ -187,7 +189,7 @@ namespace Team2GroupProject.DataSentinel.Detection
 
             var keyMaterial = string.Join("|", new[]
             {
-                "large-readwrite",
+                "bulk-operation",
                 rule.Id.ToString("N"),
                 rule.EventType?.ToString() ?? "Any",
                 rule.GroupByField?.ToString() ?? "All",

--- a/aspnet-core/src/Team2GroupProject.Core/DataSentinel/AlertRules/AlertRuleType.cs
+++ b/aspnet-core/src/Team2GroupProject.Core/DataSentinel/AlertRules/AlertRuleType.cs
@@ -19,9 +19,7 @@ namespace Team2GroupProject.DataSentinel.AlertRules
         PrivilegedAction = 3,
 
         /// <summary>Fires when a single operation affects a row count exceeding the threshold.</summary>
-        BulkOperation = 4,
-
-        /// <summary>Fires when read or write operations exceed specified row count thresholds within the time window.</summary>
-        LargeReadWrite = 5
+        BulkOperation = 4
+        // LargeReadWrite (5) was removed — BulkOperation covers read/write row-count threshold detection.
     }
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>PR: Consolidate LargeReadWrite into BulkOperation — Fix P1 Evaluator Dead Zone</h1>
<h2>What This PR Does</h2>
<p>Fixes a P1 bug where every <code>LargeReadWrite</code> alert rule was silently skipped during
anomaly detection, making the <code>LargeReadWriteEvaluator</code> completely non-functional.
<code>LargeReadWrite</code> is retired and consolidated into the existing <code>BulkOperation</code> type,
which already has the correct validation and evaluation path.</p>
<hr>
<h2>Problem</h2>
<p><code>AlertRule.EnsureConfigurationIsValid()</code> had no <code>case</code> for <code>AlertRuleType.LargeReadWrite</code>,
so it fell into the <code>default</code> branch and threw a <code>UserFriendlyException</code> for every rule
of that type. <code>LargeReadWriteEvaluator.CanEvaluate()</code> catches that exception and returns
<code>false</code>, silently incrementing <code>SkippedRuleCount</code> with no error surfaced to the caller.</p>
<p>The result: zero large read/write alerts could ever be created, across all tenants,
with no visible indication that anything was wrong.</p>
<hr>
<h2>Root Cause</h2>
<pre><code>ThresholdBased   ✅ validated
RepeatedFailure  ✅ validated
BulkOperation    ✅ validated
OutOfHours       ✅ validated
PrivilegedAction ✅ validated
LargeReadWrite   ❌ no case → throws → CanEvaluate() returns false → rule skipped
</code></pre>
<hr>
<h2>Changes</h2>

File | Change
-- | --
AlertRules/AlertRuleType.cs | Removed LargeReadWrite = 5; added consolidation comment on BulkOperation = 4
Detection/LargeReadWriteEvaluator.cs | GetEnabledByTypeAsync now loads BulkOperation rules
Detection/LargeReadWriteEvaluator.cs | Correlation key prefix changed from "large-readwrite" to "bulk-operation"
Detection/LargeReadWriteEvaluator.cs | Class and method doc-comments updated to reflect "bulk operation"


<h3>What Was Not Changed</h3>
<ul>
<li><code>LargeReadWriteEvaluator</code>, <code>ILargeReadWriteEvaluator</code>, <code>LargeReadWriteRuleEvaluationResultDto</code> — public API surface, out of scope.</li>
<li><code>AnomalyDetectionAppService</code> — depends on the interface only, unaffected.</li>
<li>Integer values of all retained <code>AlertRuleType</code> members.</li>
</ul>
<hr>

</body>
</html>