### PR TITLE
feat: add default alert rule seeder and integrate with activity event…

### DIFF
--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/ActivityEvents/ActivityEventAppService.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/ActivityEvents/ActivityEventAppService.cs
@@ -15,6 +15,7 @@ using Microsoft.EntityFrameworkCore;
 using Team2GroupProject.Authorization;
 using Team2GroupProject.DataSentinel;
 using Team2GroupProject.DataSentinel.ActivityEvents.Dto;
+using Team2GroupProject.DataSentinel.AlertRules;
 using Team2GroupProject.DataSentinel.Detection;
 using Team2GroupProject.DataSentinel.Monitoring;
 
@@ -51,6 +52,7 @@ namespace Team2GroupProject.DataSentinel.ActivityEvents
         private readonly IActivityEventRepository _activityEventRepository;
         private readonly IMonitoredServerRepository _monitoredServerRepository;
         private readonly IMonitoredDatabaseRepository _monitoredDatabaseRepository;
+        private readonly IDefaultAlertRuleSeeder _defaultAlertRuleSeeder;
         private readonly IThresholdRuleEvaluator _thresholdRuleEvaluator;
         private readonly IOutOfHoursRuleEvaluator _outOfHoursRuleEvaluator;
         private readonly IRepeatedFailureEvaluator _repeatedFailureEvaluator;
@@ -61,6 +63,7 @@ namespace Team2GroupProject.DataSentinel.ActivityEvents
             IActivityEventRepository activityEventRepository,
             IMonitoredServerRepository monitoredServerRepository,
             IMonitoredDatabaseRepository monitoredDatabaseRepository,
+            IDefaultAlertRuleSeeder defaultAlertRuleSeeder,
             IThresholdRuleEvaluator thresholdRuleEvaluator,
             IOutOfHoursRuleEvaluator outOfHoursRuleEvaluator,
             IRepeatedFailureEvaluator repeatedFailureEvaluator,
@@ -70,6 +73,7 @@ namespace Team2GroupProject.DataSentinel.ActivityEvents
             _activityEventRepository = activityEventRepository;
             _monitoredServerRepository = monitoredServerRepository;
             _monitoredDatabaseRepository = monitoredDatabaseRepository;
+            _defaultAlertRuleSeeder = defaultAlertRuleSeeder;
             _thresholdRuleEvaluator = thresholdRuleEvaluator;
             _outOfHoursRuleEvaluator = outOfHoursRuleEvaluator;
             _repeatedFailureEvaluator = repeatedFailureEvaluator;
@@ -284,6 +288,8 @@ namespace Team2GroupProject.DataSentinel.ActivityEvents
             {
                 return summary;
             }
+
+            await _defaultAlertRuleSeeder.EnsureSeededAsync(tenantId);
 
             var createdAlertIds = new HashSet<Guid>();
             var anchors = acceptedEvents

--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/AlertRules/DefaultAlertRuleSeeder.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/AlertRules/DefaultAlertRuleSeeder.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Abp.Dependency;
+using Abp.Domain.Uow;
+using Microsoft.EntityFrameworkCore;
+using Team2GroupProject.DataSentinel.ActivityEvents;
+
+namespace Team2GroupProject.DataSentinel.AlertRules
+{
+    public class DefaultAlertRuleSeeder : IDefaultAlertRuleSeeder, ITransientDependency
+    {
+        private readonly IAlertRuleRepository _alertRuleRepository;
+        private readonly IUnitOfWorkManager _unitOfWorkManager;
+
+        public DefaultAlertRuleSeeder(
+            IAlertRuleRepository alertRuleRepository,
+            IUnitOfWorkManager unitOfWorkManager)
+        {
+            _alertRuleRepository = alertRuleRepository;
+            _unitOfWorkManager = unitOfWorkManager;
+        }
+
+        public async Task<int> EnsureSeededAsync(int tenantId)
+        {
+            var existingRuleCount = await _alertRuleRepository.GetAll()
+                .CountAsync(x => x.TenantId == tenantId);
+
+            if (existingRuleCount > 0)
+            {
+                return 0;
+            }
+
+            var defaultRules = BuildDefaultRules(tenantId);
+
+            foreach (var rule in defaultRules)
+            {
+                await _alertRuleRepository.InsertAsync(rule);
+            }
+
+            if (defaultRules.Count > 0)
+            {
+                await _unitOfWorkManager.Current.SaveChangesAsync();
+            }
+
+            return defaultRules.Count;
+        }
+
+        private static List<AlertRule> BuildDefaultRules(int tenantId)
+        {
+            return new List<AlertRule>
+            {
+                new AlertRule(
+                    tenantId,
+                    "Default: Failed login burst",
+                    AlertRuleType.RepeatedFailure,
+                    ActivitySeverity.High,
+                    windowMinutes: 15,
+                    thresholdCount: 3)
+                {
+                    Description = "Creates an alert when the same actor accumulates repeated failed logins within a short window.",
+                    EventType = ActivityEventType.Login,
+                    GroupByField = AlertRuleGroupByField.ActorUser
+                },
+                new AlertRule(
+                    tenantId,
+                    "Default: Write spike",
+                    AlertRuleType.ThresholdBased,
+                    ActivitySeverity.High,
+                    windowMinutes: 15,
+                    thresholdCount: 3)
+                {
+                    Description = "Creates an alert when the same actor performs an unusual burst of write activity.",
+                    EventType = ActivityEventType.Write,
+                    GroupByField = AlertRuleGroupByField.ActorUser
+                },
+                new AlertRule(
+                    tenantId,
+                    "Default: Large write operation",
+                    AlertRuleType.BulkOperation,
+                    ActivitySeverity.Critical,
+                    windowMinutes: 15,
+                    thresholdCount: 500)
+                {
+                    Description = "Creates an alert when a single write operation affects a large number of rows.",
+                    EventType = ActivityEventType.Write,
+                    GroupByField = AlertRuleGroupByField.ActorUser
+                },
+                new AlertRule(
+                    tenantId,
+                    "Default: After-hours risky activity",
+                    AlertRuleType.OutOfHours,
+                    ActivitySeverity.High,
+                    windowMinutes: 0,
+                    thresholdCount: 1)
+                {
+                    Description = "Creates an alert for risky write or privileged activity happening outside normal business hours."
+                },
+                new AlertRule(
+                    tenantId,
+                    "Default: Privileged action activity",
+                    AlertRuleType.PrivilegedAction,
+                    ActivitySeverity.High,
+                    windowMinutes: 0,
+                    thresholdCount: 1)
+                {
+                    Description = "Creates an alert whenever a privileged or permission-changing action is recorded."
+                }
+            };
+        }
+    }
+}

--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/AlertRules/IDefaultAlertRuleSeeder.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/AlertRules/IDefaultAlertRuleSeeder.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Team2GroupProject.DataSentinel.AlertRules
+{
+    public interface IDefaultAlertRuleSeeder
+    {
+        Task<int> EnsureSeededAsync(int tenantId);
+    }
+}

--- a/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Monitoring/MonitoringInfrastructureAppService.cs
+++ b/aspnet-core/src/Team2GroupProject.Application/DataSentinel/Monitoring/MonitoringInfrastructureAppService.cs
@@ -10,6 +10,7 @@ using Abp.Runtime.Session;
 using Abp.UI;
 using Microsoft.EntityFrameworkCore;
 using Team2GroupProject.Authorization;
+using Team2GroupProject.DataSentinel.AlertRules;
 using Team2GroupProject.DataSentinel.Monitoring.Dto;
 
 namespace Team2GroupProject.DataSentinel.Monitoring
@@ -20,15 +21,18 @@ namespace Team2GroupProject.DataSentinel.Monitoring
         private readonly IMonitoredServerRepository _monitoredServerRepository;
         private readonly IMonitoredDatabaseRepository _monitoredDatabaseRepository;
         private readonly IMonitoredTableRepository _monitoredTableRepository;
+        private readonly IDefaultAlertRuleSeeder _defaultAlertRuleSeeder;
 
         public MonitoringInfrastructureAppService(
             IMonitoredServerRepository monitoredServerRepository,
             IMonitoredDatabaseRepository monitoredDatabaseRepository,
-            IMonitoredTableRepository monitoredTableRepository)
+            IMonitoredTableRepository monitoredTableRepository,
+            IDefaultAlertRuleSeeder defaultAlertRuleSeeder)
         {
             _monitoredServerRepository = monitoredServerRepository;
             _monitoredDatabaseRepository = monitoredDatabaseRepository;
             _monitoredTableRepository = monitoredTableRepository;
+            _defaultAlertRuleSeeder = defaultAlertRuleSeeder;
         }
 
         public async Task<ListResultDto<MonitoredServerDto>> GetMonitoredServersAsync()
@@ -253,6 +257,7 @@ namespace Team2GroupProject.DataSentinel.Monitoring
                 }
             }
 
+            await _defaultAlertRuleSeeder.EnsureSeededAsync(tenantId);
             CurrentUnitOfWork.SaveChanges();
 
             var servers = await LoadInfrastructureAsync(tenantId);

--- a/aspnet-core/test/Team2GroupProject.Tests/DataSentinel/ActivityEvents/ActivityEventAppService_Tests.cs
+++ b/aspnet-core/test/Team2GroupProject.Tests/DataSentinel/ActivityEvents/ActivityEventAppService_Tests.cs
@@ -194,6 +194,67 @@ namespace Team2GroupProject.Tests.DataSentinel.ActivityEvents
         }
 
         [Fact]
+        public async Task IngestAsync_should_seed_default_rules_and_create_alerts_when_the_tenant_has_no_rules()
+        {
+            var tenantId = AbpSession.TenantId!.Value;
+            var database = await CreateDatabaseAsync(tenantId);
+            var evaluationTime = DateTime.UtcNow;
+
+            var result = await _activityEventAppService.IngestAsync(new IngestActivityEventsInput
+            {
+                Events = new List<ActivityEventIngestionItemDto>
+                {
+                    new ActivityEventIngestionItemDto
+                    {
+                        DatabaseId = database.Id,
+                        EventTime = evaluationTime.AddMinutes(-2),
+                        EventType = ActivityEventType.Login,
+                        ActorUser = "burst-user",
+                        ActorIp = "10.10.10.10",
+                        Severity = ActivitySeverity.Medium,
+                        IsSuccess = false,
+                        FailureReason = "Invalid password"
+                    },
+                    new ActivityEventIngestionItemDto
+                    {
+                        DatabaseId = database.Id,
+                        EventTime = evaluationTime.AddMinutes(-1),
+                        EventType = ActivityEventType.Login,
+                        ActorUser = "burst-user",
+                        ActorIp = "10.10.10.10",
+                        Severity = ActivitySeverity.Medium,
+                        IsSuccess = false,
+                        FailureReason = "Invalid password"
+                    },
+                    new ActivityEventIngestionItemDto
+                    {
+                        DatabaseId = database.Id,
+                        EventTime = evaluationTime,
+                        EventType = ActivityEventType.Login,
+                        ActorUser = "burst-user",
+                        ActorIp = "10.10.10.10",
+                        Severity = ActivitySeverity.Medium,
+                        IsSuccess = false,
+                        FailureReason = "Invalid password"
+                    }
+                }
+            });
+
+            result.AcceptedCount.ShouldBe(3);
+            result.DetectionSummary.CreatedAlertCount.ShouldBe(1);
+
+            var persistedCounts = await UsingDbContextAsync(async context =>
+                await Task.FromResult(new
+                {
+                    RuleCount = context.AlertRules.Count(x => x.TenantId == tenantId),
+                    AlertCount = context.SecurityAlerts.Count(x => x.TenantId == tenantId)
+                }));
+
+            persistedCounts.RuleCount.ShouldBeGreaterThan(0);
+            persistedCounts.AlertCount.ShouldBe(1);
+        }
+
+        [Fact]
         public async Task ImportBatchAsync_should_reject_duplicate_source_events_within_the_same_batch()
         {
             var tenantId = AbpSession.TenantId!.Value;

--- a/aspnet-core/test/Team2GroupProject.Tests/DataSentinel/Monitoring/MonitoringInfrastructureAppService_Tests.cs
+++ b/aspnet-core/test/Team2GroupProject.Tests/DataSentinel/Monitoring/MonitoringInfrastructureAppService_Tests.cs
@@ -51,6 +51,11 @@ namespace Team2GroupProject.Tests.DataSentinel.Monitoring
             persistedCounts.Servers.ShouldBe(1);
             persistedCounts.Databases.ShouldBe(2);
             persistedCounts.Tables.ShouldBe(6);
+
+            var persistedRuleCount = await UsingDbContextAsync(async context =>
+                await Task.FromResult(context.AlertRules.Count()));
+
+            persistedRuleCount.ShouldBeGreaterThan(0);
         }
 
         [Fact]
@@ -110,6 +115,25 @@ namespace Team2GroupProject.Tests.DataSentinel.Monitoring
             persisted.DatabaseId.ShouldBe(database.Id);
             persisted.ServerId.ShouldBe(database.ServerId);
             persisted.ActorUser.ShouldBe("admin");
+        }
+
+        [Fact]
+        public async Task BootstrapDemoAsync_should_seed_default_alert_rules_for_the_current_tenant()
+        {
+            await _monitoringInfrastructureAppService.BootstrapDemoAsync(new BootstrapMonitoringDemoInput());
+
+            var persistedRules = await UsingDbContextAsync(async context =>
+                await Task.FromResult(context.AlertRules
+                    .Where(x => x.TenantId == AbpSession.TenantId)
+                    .OrderBy(x => x.Name)
+                    .Select(x => x.Name)
+                    .ToList()));
+
+            persistedRules.ShouldContain("Default: Failed login burst");
+            persistedRules.ShouldContain("Default: Write spike");
+            persistedRules.ShouldContain("Default: Large write operation");
+            persistedRules.ShouldContain("Default: After-hours risky activity");
+            persistedRules.ShouldContain("Default: Privileged action activity");
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a mechanism to automatically seed default alert rules for tenants when ingesting activity events or bootstrapping monitoring infrastructure. This ensures that every tenant starts with a baseline set of alert rules, improving security and detection coverage. The changes include the implementation of the seeder, integration into relevant application services, and comprehensive tests to verify the seeding and alert creation behavior.

Default Alert Rule Seeding:

* Added the `IDefaultAlertRuleSeeder` interface and its implementation `DefaultAlertRuleSeeder`, which seeds a set of default alert rules for a tenant if none exist. (`aspnet-core/src/Team2GroupProject.Application/DataSentinel/AlertRules/IDefaultAlertRuleSeeder.cs`, `aspnet-core/src/Team2GroupProject.Application/DataSentinel/AlertRules/DefaultAlertRuleSeeder.cs`) [[1]](diffhunk://#diff-7ef3ffe74faa1d31e65995f303f880c1fba43e1492fc5cf9bfc36d8f437e6e5eR1-R9) [[2]](diffhunk://#diff-9759349acc1b441acd8c783ca3aab7468fc134b15fc1a0277b90eefa78d93764R1-R111)

Integration with Application Services:

* Injected and invoked `IDefaultAlertRuleSeeder` in `ActivityEventAppService` and `MonitoringInfrastructureAppService` to ensure default alert rules are seeded during event ingestion and demo bootstrap operations. (`aspnet-core/src/Team2GroupProject.Application/DataSentinel/ActivityEvents/ActivityEventAppService.cs`, `aspnet-core/src/Team2GroupProject.Application/DataSentinel/Monitoring/MonitoringInfrastructureAppService.cs`) [[1]](diffhunk://#diff-459ebb1b18e10856a431d0b9772ff99b934e4c92aa63ef8fb7ac38327556c747R18) [[2]](diffhunk://#diff-459ebb1b18e10856a431d0b9772ff99b934e4c92aa63ef8fb7ac38327556c747R55) [[3]](diffhunk://#diff-459ebb1b18e10856a431d0b9772ff99b934e4c92aa63ef8fb7ac38327556c747R66) [[4]](diffhunk://#diff-459ebb1b18e10856a431d0b9772ff99b934e4c92aa63ef8fb7ac38327556c747R76) [[5]](diffhunk://#diff-459ebb1b18e10856a431d0b9772ff99b934e4c92aa63ef8fb7ac38327556c747R292-R293) [[6]](diffhunk://#diff-cc7325f28879d783cd701603cee6eb57c3b0214b9a3589fca264ea2e7ddbda63R13) [[7]](diffhunk://#diff-cc7325f28879d783cd701603cee6eb57c3b0214b9a3589fca264ea2e7ddbda63R24-R35) [[8]](diffhunk://#diff-cc7325f28879d783cd701603cee6eb57c3b0214b9a3589fca264ea2e7ddbda63R260)

Testing and Validation:

* Added tests to verify that default alert rules are seeded and alerts are created when a tenant ingests activity events without existing rules. (`aspnet-core/test/Team2GroupProject.Tests/DataSentinel/ActivityEvents/ActivityEventAppService_Tests.cs`)
* Added tests to ensure default alert rules are seeded during monitoring infrastructure bootstrap and validated their presence in the database. (`aspnet-core/test/Team2GroupProject.Tests/DataSentinel/Monitoring/MonitoringInfrastructureAppService_Tests.cs`) [[1]](diffhunk://#diff-1c5f4f61e9204649f71fffc3b997829d6c5a2258978b076fb7fd9eaf05c44e0dR54-R58) [[2]](diffhunk://#diff-1c5f4f61e9204649f71fffc3b997829d6c5a2258978b076fb7fd9eaf05c44e0dR119-R137)… and monitoring services