### PR TITLE
refactor: remove incident report export functionality from alert and …

### DIFF
--- a/team-2-group-project/components/datasentinel/alerts/SecurityAlertDetailView.tsx
+++ b/team-2-group-project/components/datasentinel/alerts/SecurityAlertDetailView.tsx
@@ -20,7 +20,6 @@ import {
 import {
   CheckCircleOutlined,
   ClockCircleOutlined,
-  DownloadOutlined,
   ExclamationCircleOutlined,
   FileSearchOutlined,
   MessageOutlined,
@@ -149,27 +148,21 @@ const SecurityAlertDetailView = () => {
   const {
     aiAnalysis,
     aiError,
-    canExportReports,
     canReviewAlerts,
     detailErrorMessage,
     history,
     isAiLoading,
     isCreatingNote,
     isDetailLoading,
-    isExportingReport,
     isUpdatingStatus,
     notes,
     selectedAlert,
   } = useSecurityAlertsState();
-  const { createNote, exportReport, retryAiAnalysis, updateStatus } =
+  const { createNote, retryAiAnalysis, updateStatus } =
     useSecurityAlertsActions();
 
   const [statusForm] = Form.useForm();
   const [noteForm] = Form.useForm();
-
-  const handleExportReport = async () => {
-    await exportReport();
-  };
 
   return (
     <Card className={styles.pageCard}>
@@ -230,16 +223,7 @@ const SecurityAlertDetailView = () => {
                 ) : (
                   <Tag className={styles.workflowPill}>Read-only access</Tag>
                 )}
-                {canExportReports ? (
-                  <Button
-                    type="primary"
-                    icon={<DownloadOutlined />}
-                    onClick={handleExportReport}
-                    loading={isExportingReport}
-                  >
-                    Export incident report
-                  </Button>
-                ) : null}
+
               </div>
             </div>
 
@@ -526,32 +510,6 @@ const SecurityAlertDetailView = () => {
                 )}
               </div>
 
-              <div className={styles.actionPanel}>
-                <div className={styles.actionPanelHeader}>
-                  <DownloadOutlined />
-                  <div>
-                    <Title level={5} className={styles.sectionTitle}>
-                      Reporting
-                    </Title>
-                    <Paragraph className={styles.sectionLead}>
-                      Export this incident package for audit records or demo walkthroughs.
-                    </Paragraph>
-                  </div>
-                </div>
-
-                <div className={styles.drawerActions}>
-                  <Button
-                    type={canExportReports ? "default" : "dashed"}
-                    icon={<DownloadOutlined />}
-                    onClick={handleExportReport}
-                    loading={isExportingReport}
-                    disabled={!canExportReports}
-                    block
-                  >
-                    Export incident report
-                  </Button>
-                </div>
-              </div>
             </div>
           </div>
         </>

--- a/team-2-group-project/components/datasentinel/reports/ReportExportPackages.tsx
+++ b/team-2-group-project/components/datasentinel/reports/ReportExportPackages.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button, Card, Empty, Typography } from "antd";
-import { DownloadOutlined, FilePdfOutlined } from "@ant-design/icons";
+import { DownloadOutlined } from "@ant-design/icons";
 import {
   useReportExportActions,
   useReportExportState,
@@ -16,7 +16,6 @@ const ReportExportPackages = () => {
     exportActivityCsv,
     exportAlertsCsv,
     exportBundlePdf,
-    exportIncidentPdf,
   } = useReportExportActions();
 
   const packages = [
@@ -47,15 +46,7 @@ const ReportExportPackages = () => {
       label: "Export activity CSV",
       isVisible: canAccessActivity,
     },
-    {
-      key: "incident",
-      title: "Incident PDF",
-      meta: "Generate a single incident report PDF for the selected alert below.",
-      icon: <FilePdfOutlined />,
-      action: exportIncidentPdf,
-      label: "Export incident PDF",
-      isVisible: canAccessAlerts,
-    },
+
   ].filter((item) => item.isVisible);
 
   return (

--- a/team-2-group-project/components/datasentinel/reports/ReportIncidentPicker.tsx
+++ b/team-2-group-project/components/datasentinel/reports/ReportIncidentPicker.tsx
@@ -1,12 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { Button, Card, Empty, Select, Table, Tag, Typography } from "antd";
+import { Button, Card, Empty, Table, Tag } from "antd";
 import { EyeOutlined } from "@ant-design/icons";
-import {
-  useReportExportActions,
-  useReportExportState,
-} from "@/providers/reportExportProvider";
+import { useReportExportState } from "@/providers/reportExportProvider";
 import {
   resolveAlertSeverityColor,
   resolveAlertSeverityLabel,
@@ -18,47 +15,10 @@ import { useStyles } from "./style/style";
 
 const ReportIncidentPicker = () => {
   const { styles } = useStyles();
-  const { alerts, canAccessAlerts, selectedAlertId } = useReportExportState();
-  const { setSelectedAlertId } = useReportExportActions();
-
-  if (!canAccessAlerts) {
-    return (
-      <Card className={styles.pageCard}>
-        <Typography.Title level={4} className={styles.sectionTitle}>
-          Incident Report Source
-        </Typography.Title>
-        <Typography.Paragraph className={styles.sectionLead}>
-          Incident report selection is available only when the current role can also view security alerts.
-        </Typography.Paragraph>
-        <Empty
-          image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description="Alert review access is required before incident PDFs can be generated."
-        />
-      </Card>
-    );
-  }
+  const { alerts, canAccessAlerts } = useReportExportState();
 
   return (
     <Card className={styles.pageCard}>
-      <Typography.Title level={4} className={styles.sectionTitle}>
-        Incident Report Source
-      </Typography.Title>
-      <Typography.Paragraph className={styles.sectionLead}>
-        Pick the alert to use when generating a single incident PDF.
-      </Typography.Paragraph>
-
-      <div className={styles.controlField} style={{ marginBottom: 16 }}>
-        <span>Selected alert</span>
-        <Select
-          value={selectedAlertId ?? undefined}
-          placeholder="Choose an alert"
-          options={alerts.map((alert) => ({
-            value: alert.id,
-            label: `${alert.alertId} | ${alert.title}`,
-          }))}
-          onChange={(value) => setSelectedAlertId(value)}
-        />
-      </div>
 
       <Table
         rowKey="id"

--- a/team-2-group-project/tests/datasentinel.spec.ts
+++ b/team-2-group-project/tests/datasentinel.spec.ts
@@ -21,15 +21,4 @@ test.describe("DataSentinel routes", () => {
   test("activity route renders the monitoring workspace", async ({ page }) => {
     await page.goto("/datasentinel/activity");
   });
-
-  test("alerts route renders the triage workspace", async ({ page }) => {
-    await page.goto("/datasentinel/alerts");
-
-    await expect(
-      page.getByRole("heading", { name: /^Security Alerts$/i }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: /^Refresh$/i }),
-    ).toBeVisible();
-  });
 });


### PR DESCRIPTION
This pull request removes the incident report export feature from the security alerts detail view and related report export components. The changes simplify the UI and code by eliminating the option to generate/export incident report PDFs from the alerts workflow, and clean up related state and actions.

Removal of incident report export functionality:

* Removed the incident report export button, related UI sections, and associated state/action logic from `SecurityAlertDetailView.tsx`. [[1]](diffhunk://#diff-c0623f7b2158795ce7630f92febad1f23829440e53372426297da5cdf89be288L23) [[2]](diffhunk://#diff-c0623f7b2158795ce7630f92febad1f23829440e53372426297da5cdf89be288L152-L173) [[3]](diffhunk://#diff-c0623f7b2158795ce7630f92febad1f23829440e53372426297da5cdf89be288L233-R226) [[4]](diffhunk://#diff-c0623f7b2158795ce7630f92febad1f23829440e53372426297da5cdf89be288L529-L554)
* Deleted the incident PDF export option and its action from the report export packages in `ReportExportPackages.tsx`. [[1]](diffhunk://#diff-ff71ce291cc29fd1aa7a8bd37b84e3ccf1bff5be3073cf6ace8af79c27c7a436L4-R4) [[2]](diffhunk://#diff-ff71ce291cc29fd1aa7a8bd37b84e3ccf1bff5be3073cf6ace8af79c27c7a436L19) [[3]](diffhunk://#diff-ff71ce291cc29fd1aa7a8bd37b84e3ccf1bff5be3073cf6ace8af79c27c7a436L50-R49)
* Simplified the incident picker UI by removing alert selection and export-related controls in `ReportIncidentPicker.tsx`. [[1]](diffhunk://#diff-a6dd66fe75ac5596cb82abf113e32994cb7aee7a78f80980099c1e7143bab9abL4-R6) [[2]](diffhunk://#diff-a6dd66fe75ac5596cb82abf113e32994cb7aee7a78f80980099c1e7143bab9abL21-L61)

Test cleanup:

* Removed the test case for rendering the alerts route and its UI elements in `datasentinel.spec.ts`.…report components