### PR TITLE
fix: change response handling to use arrayBuffer for binary data

### DIFF
--- a/team-2-group-project/app/api/proxy/[...path]/route.ts
+++ b/team-2-group-project/app/api/proxy/[...path]/route.ts
@@ -39,9 +39,9 @@ async function handleRequest(
     body,
   });
 
-  const responseText = await response.text();
+  const responseBody = await response.arrayBuffer();
 
-  return new NextResponse(responseText, {
+  return new NextResponse(responseBody, {
     status: response.status,
     headers: {
       "Content-Type": response.headers.get("content-type") || "application/json",


### PR DESCRIPTION
**Summary**
The Next.js proxy route (/api/proxy/[...path]) was reading all backend responses with response.text(), which corrupts binary data by interpreting raw bytes as a UTF-8 string
Changed to response.arrayBuffer() so binary responses (e.g. PDF exports) are passed through intact
JSON and text responses are unaffected since they are also just bytes and NextResponse handles both correctly

**Root cause**
The Export Report endpoint was returning a valid PDF from the backend (confirmed via Swagger and Content-Type: application/pdf in the network tab) but the downloaded file was blank on the deployed site. The proxy was corrupting the binary content before it reached the browser.