### PR TITLE
fix: change UpdateStatus request method from POST to PUT

### DIFF
--- a/team-2-group-project/utils/datasentinel/alertsService.ts
+++ b/team-2-group-project/utils/datasentinel/alertsService.ts
@@ -49,7 +49,7 @@ export const getSecurityAlertById = async (id: string) => {
 export const updateSecurityAlertStatus = async (
   input: IUpdateAlertStatusInput,
 ) => {
-  await axiosInstance().post("/api/services/app/SecurityAlert/UpdateStatus", input);
+  await axiosInstance().put("/api/services/app/SecurityAlert/UpdateStatus", input);
 };
 
 export const bulkUpdateSecurityAlertStatus = async (


### PR DESCRIPTION
Backend returns 405 Method Not Allowed because the SecurityAlert/UpdateStatus endpoint expects PUT, not POST.